### PR TITLE
Add 1wire support to MOTOLAB target on UART1

### DIFF
--- a/src/main/io/serial_1wire.c
+++ b/src/main/io/serial_1wire.c
@@ -62,6 +62,15 @@ const escHardware_t escHardware[ESC_COUNT] = {
   { GPIOB, 9 },
   { GPIOA, 2 },
   { GPIOA, 3 }
+#elif MOTOLAB
+  { GPIOA, 4 },
+  { GPIOA, 6 },
+  { GPIOB, 0 },
+  { GPIOB, 1 },
+  { GPIOA, 1 },
+  { GPIOA, 2 },
+  { GPIOA, 3 },
+  { GPIOA, 8 }
 #endif
 };
 

--- a/src/main/target/MOTOLAB/target.h
+++ b/src/main/target/MOTOLAB/target.h
@@ -176,3 +176,10 @@
 #define BIND_PORT GPIOB
 #define BIND_PIN Pin_4
 
+#define USE_SERIAL_1WIRE
+#define ESC_COUNT 8
+#define S1W_TX_GPIO         GPIOB
+#define S1W_TX_PIN          GPIO_Pin_6
+#define S1W_RX_GPIO         GPIOB
+#define S1W_RX_PIN          GPIO_Pin_7
+


### PR DESCRIPTION
Added defines in MOTOLAB target.h file for 1wire programming support on UART1 and added pin mappings for PWM timer outputs in serial_1wire.c

Tested and working for ESC passthrough programming with Littlebee 20A