### PR TITLE
Floating point inflight adjustments adjust by 0.01 instead of 0.1

### DIFF
--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -529,7 +529,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
         case ADJUSTMENT_PITCH_ROLL_P:
         case ADJUSTMENT_PITCH_P:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
-                newFloatValue = constrainf(pidProfile->P_f[PIDPITCH] + (float)(delta / 10.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                newFloatValue = constrainf(pidProfile->P_f[PIDPITCH] + (float)(delta / 100.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->P_f[PIDPITCH] = newFloatValue;
                 blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_PITCH_P, newFloatValue);
             } else {
@@ -543,7 +543,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             // follow though for combined ADJUSTMENT_PITCH_ROLL_P
         case ADJUSTMENT_ROLL_P:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
-                newFloatValue = constrainf(pidProfile->P_f[PIDROLL] + (float)(delta / 10.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                newFloatValue = constrainf(pidProfile->P_f[PIDROLL] + (float)(delta / 100.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->P_f[PIDROLL] = newFloatValue;
                 blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_ROLL_P, newFloatValue);
             } else {
@@ -606,7 +606,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             break;
         case ADJUSTMENT_YAW_P:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
-                newFloatValue = constrainf(pidProfile->P_f[PIDYAW] + (float)(delta / 10.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                newFloatValue = constrainf(pidProfile->P_f[PIDYAW] + (float)(delta / 100.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->P_f[PIDYAW] = newFloatValue;
                 blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_YAW_P, newFloatValue);
             } else {

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -673,9 +673,9 @@ TEST_F(RcControlsAdjustmentsTest, processPIDIncreasePidController2)
     EXPECT_EQ(adjustmentStateMask, expectedAdjustmentStateMask);
 
     // and
-    EXPECT_EQ(0.1f, pidProfile.P_f[PIDPITCH]);
-    EXPECT_EQ(5.1f, pidProfile.P_f[PIDROLL]);
-    EXPECT_EQ(7.1f, pidProfile.P_f[PIDYAW]);
+    EXPECT_EQ(0.01f, pidProfile.P_f[PIDPITCH]);
+    EXPECT_EQ(5.01f, pidProfile.P_f[PIDROLL]);
+    EXPECT_EQ(7.01f, pidProfile.P_f[PIDYAW]);
     EXPECT_EQ(10.01f, pidProfile.I_f[PIDPITCH]);
     EXPECT_EQ(15.01f, pidProfile.I_f[PIDROLL]);
     EXPECT_EQ(17.01f, pidProfile.I_f[PIDYAW]);


### PR DESCRIPTION
I posted this one against cleanflight here https://github.com/cleanflight/cleanflight/pull/1293 but as mentioned in the comments, it's not very non-beta friendly since the extra decimal place in the P values aren't shown in the configurator.

Figured beta users might appreciate it but I can totally understand that *having* to use the CLI for now unless you're running a dev configurator could make this a no-go.