### PR TITLE
Inhibit the buzzer on USB power, if batterycellcount < 2

### DIFF
--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -211,7 +211,7 @@ static const beeperTableEntry_t *currentBeeperEntry = NULL;
  */
 void beeper(beeperMode_e mode)
 {
-    if (mode == BEEPER_SILENCE) {
+    if (mode == BEEPER_SILENCE || (feature(FEATURE_VBAT) && (batteryCellCount < 2))) {
         beeperSilence();
         return;
     }


### PR DESCRIPTION
MotoLab targets have the buzzer powered on USB power, really annoying if the transmitter is off.